### PR TITLE
Update Forge to 37.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -139,7 +139,7 @@ dependencies {
     // Specify the version of Minecraft to use. If this is any group other than 'net.minecraft', it is assumed
     // that the dep is a ForgeGradle 'patcher' dependency, and its patches will be applied.
     // The userdev artifact is a special name and will get all sorts of transformations applied to it.
-    minecraft 'net.minecraftforge:forge:1.17.1-37.0.109'
+    minecraft 'net.minecraftforge:forge:1.17.1-37.1.0'
 
     // Real mod deobf dependency examples - these get remapped to your current mappings
     // compileOnly fg.deobf("mezz.jei:jei-${mc_version}:${jei_version}:api") // Adds JEI API as a compile dependency


### PR DESCRIPTION
This change updates Forge version to 37.1.0 (latest against Minecraft 1.17).